### PR TITLE
use error events instead of throwing, order templates by FIFO, make rotation optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Example
     options = host: 'localhost', port: 27017, db: 'test'
     connection = new mojo.Connection options
 
+    # Listen to connection errors
+    connection.on 'error', console.error
+
     # Put some jobs into the queue
     connection.enqueue Addition.name, 1, 1
     connection.enqueue Addition.name, 2, 4
@@ -36,6 +39,7 @@ Example
 
     # Now you need a worker who will process the jobs
     worker = new mojo.Worker connection, [ Addition ]
+    worker.on 'error', console.error
     worker.poll()
 
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,13 @@
   "keywords": ["queue", "jobqueue", "mongo", "mongodb"],
   "author": "Tomas Carnecky",
   "homepage": "https://github.com/wereHamster/mojo",
-  "version": "0.0.4",
+  "version": "0.1.0",
   "licenses": [{ "type": "Unlicense", "url": "http://unlicense.org/" }],
   "engines": { "node": ">=0.4.0" },
   "directories": { "lib": "./lib" },
   "main": "./lib/mojo",
-  "dependencies": { "mongodb": "~> 0.9.2" }
+  "dependencies": { "mongodb": "~> 1.2.14" },
+  "scripts": {
+    "prepublish": "make compile"
+  }
 }


### PR DESCRIPTION
Hi, we are using mojo in production. We had an issue which we couldn't understand for a long time. Sometimes tasks were not processed and they timed out. After a deep investigation I found the reason. Mojo is doing the template rotation, which is ok if one has lots of tasks of one type so tasks of a second type need to wait too long. The downside of this approach is if you have, lets say 10 different templates and we do polling every 1 second, we will come to process the 10. template in 10 seconds which is a way too long. Under load we have lots of tasks, due to this timeout our worker where not fast enough to complete them and they timed out.

We are using this version in production since 2 weeks and it seems to be fine.

Changes:
- I have changed the default template rotation behaviour to FIFO, rotaion can still be done optionally.
- Errors will be emited now, hot thrown ... it is a bad idea to throw async errors in node, because they land in uncaughtException handler and this errors have an empty stack currently.

Cheers,
Oleg
