### PR TITLE
Enqueue settings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 lib
+coverage

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,5 @@
 Makefile
 examples/
 src/
+test/
+coverage/

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,24 @@
+.PHONY: test compile-test compile clean publish install
 
-.PHONY: test
-test:
-	coffee test/*.coffee
+test: compile compile-test run-test clean
 
+compile-test:
+	@./node_modules/.bin/coffee -c test/*.coffee test/**/*.coffee
+
+clean-test:
+	@rm -fr test/*.js test/**/*.js
+
+run-test:
+	@node test/tests.js
 
 compile:
-	./node_modules/.bin/coffee -c -o lib src/*.coffee
+	@./node_modules/.bin/coffee -c -o lib src/*.coffee
 
-clean:
-	rm -fr lib/
-
+clean: clean-test
+	@rm -fr lib/
 
 publish: compile
 	npm publish
 
 install: compile
 	npm install
-
-

--- a/package.json
+++ b/package.json
@@ -30,10 +30,13 @@
     "mongodb": "~1.4.6"
   },
   "devDependencies": {
-    "coffee-script": "^1.8.0"
+    "coffee-script": "^1.8.0",
+    "lodash": "^2.4.1",
+    "qunit": "^0.7.5"
   },
   "scripts": {
-    "prepublish": "make compile"
+    "prepublish": "make compile",
+    "test": "make test"
   },
   "contributors": [
     {

--- a/src/queue.coffee
+++ b/src/queue.coffee
@@ -21,33 +21,33 @@ class exports.Connection extends EventEmitter
   # hash. Two options are currently supported: expires and timeout.
   constructor: (options) ->
     options or options = {}
-    @ensureConnection options
     @expires = options.expires or 60 * 60 * 1000
     @timeout = options.timeout or 10 * 1000
     @maxAttempts = options.maxAttempts or 5
+    @queue = []
+    setImmediate () =>
+      @ensureConnection options
 
   # Open a connection to the MongoDB server. Queries created while we are
   # connecting are queued and executed after the connection is established.
   ensureConnection: (opt) ->
-    @queue = []
-
     afterConnectionEstablished = (err) =>
-      @emit('error', err) if err
+      return @emit('error', err) if err
 
       # Make a lame read request to the database. This will return an error
       # if the client is not authorized to access it.
       db.collectionNames (err) =>
-        @emit('error', err) if err
+        return @emit('error', err) if err
 
         db.collection 'queue', (err, collection) =>
-          @emit('error', err) if err
+          return @emit('error', err) if err
 
           @collection = collection
           fn(collection) for fn in @queue if @queue
           delete @queue
 
           collection.ensureIndex [ ['expires'], ['owner'], ['queue'] ], (err) =>
-            @emit('error', err) if err
+            if err then @emit('error', err) else @emit('connected')
 
     # Use an existing database connection if one is passed
     # Use duck-typing because we can't rely on opt.db being instanceof mongodb.Db
@@ -88,8 +88,9 @@ class exports.Connection extends EventEmitter
   # up to the individual workers.
   enqueue: (queue, args..., callback)->
     @exec (collection) =>
+      return callback(new Error('Last argument must be a callback')) if typeof callback isnt 'function'
       startDate = queue.startDate or Date.now()
-      expires = new Date(startDate + (queue.expires or @expires))
+      expires = new Date(+startDate + (queue.expires or @expires))
       attempts = 0
       queue = queue.queue or queue
 
@@ -177,6 +178,8 @@ class exports.Worker extends require('events').EventEmitter
 
 
   poll: ->
+    return if @stopped
+
     # If there are too many pending jobs, sleep for a bit.
     if @pending >= @workers
       return @sleep()
@@ -196,6 +199,8 @@ class exports.Worker extends require('events').EventEmitter
           @emit 'error', new Error("Unknown template '#{ name }'")
         process.nextTick =>
           @poll()
+      else
+        @emit 'drained' if @pending is 0
 
       @sleep()
 
@@ -216,18 +221,28 @@ class exports.Worker extends require('events').EventEmitter
   # already active make sure to clear it first.
   sleep: ->
     clearTimeout @pollTimeout if @pollTimeout
-    @pollTimeout = setTimeout =>
-      @pollTimeout = null
-      @poll()
-    , @timeout
+
+    if not @stopped
+      @pollTimeout = setTimeout =>
+        @pollTimeout = null
+        @poll()
+      , @timeout
 
 
   complete: (err, doc) ->
-    cb = => --@pending; @poll()
+    cb = =>
+      --@pending
+      @poll() if not @stopped
+      @emit 'stopped' if @pending is 0
 
     if err?
       @emit 'error', err
       @connection.release doc, cb
     else
       @connection.complete doc, cb
+
+  stop: () ->
+    @stopped = true
+    clearTimeout @pollTimeout
+    @emit 'stopped' if @pending is 0
 

--- a/test/connection.coffee
+++ b/test/connection.coffee
@@ -1,0 +1,79 @@
+_ = require 'lodash'
+queue = require '..'
+db = require './utils/db'
+
+QUnit.module 'Connection',
+  teardown: () ->
+    stop()
+    db.teardown () ->
+      start()
+
+test 'test connection with defaults', () ->
+  expect 3
+
+  stop()
+
+  db.connect 'mongodb://localhost:27017/queue', (err) ->
+    ok !err, 'connection to mongodb failed'
+    conn = new queue.Connection
+    conn.once 'connected', () ->
+      db.conn.collection('queue').indexes (err, indexes) ->
+        ok !err, 'getting indexes failed'
+        equal indexes.length, 2
+        start()
+
+test 'providing a connection', () ->
+  expect 3
+
+  stop()
+
+  db.connect 'mongodb://localhost:27017/test-queue', (err) ->
+    ok !err, 'connection to mongodb failed'
+    conn = new queue.Connection(db: db.conn)
+    conn.once 'connected', () ->
+      db.conn.collection('queue').indexes (err, indexes) ->
+        ok !err, 'getting indexes failed'
+        equal indexes.length, 2
+        start()
+
+test 'enqueue a task', () ->
+  expect 7
+
+  stop()
+
+  db.connect 'mongodb://localhost:27017/test-queue', (err) ->
+    ok !err, 'connection to mongodb failed'
+    conn = new queue.Connection(db: db.conn)
+    conn.once 'connected', () ->
+      conn.enqueue 'Addition', () ->
+        db.conn.collection('queue').find().toArray (err, docs) ->
+          ok !err, 'error retrieving documents'
+          equal docs.length, 1
+          doc = docs[0]
+          equal doc.queue, 'Addition'
+          ok _.isDate(doc.expires)
+          equal doc.args.length, 0
+          equal doc.attempts, 0
+          start()
+
+test 'enqueue a task overriding its settings', () ->
+  expect 5
+
+  stop()
+
+  db.connect 'mongodb://localhost:27017/test-queue', (err) ->
+    ok !err, 'connection to mongodb failed'
+    conn = new queue.Connection(db: db.conn)
+    conn.once 'connected', () ->
+      task =
+        queue: 'Testing',
+        startDate: new Date(0),
+        expires: 90 * 60 * 1000
+      conn.enqueue task, () ->
+        db.conn.collection('queue').find().toArray (err, docs) ->
+          ok !err, 'error retrieving documents'
+          equal docs.length, 1
+          doc = docs[0]
+          equal doc.queue, 'Testing'
+          equal +doc.expires, +new Date(90 * 60 * 1000)
+          start()

--- a/test/template.coffee
+++ b/test/template.coffee
@@ -1,0 +1,46 @@
+queue = require '..'
+
+QUnit.module 'Template'
+
+test 'perform throws if not implemented', () ->
+  expect 1
+
+  class Empty extends queue.Template
+
+  empty = new Empty
+  throws(
+    () -> empty.perform()
+    'Unimplemented template should throw an error on perform'
+  )
+
+test 'executes an addition', () ->
+  expect 3
+
+  class Addition extends queue.Template
+    perform: (a, b) ->
+      @worker.result = a + b
+      @complete()
+
+  worker =
+    complete: (err, doc) ->
+      equal err, undefined
+      deepEqual doc.args, [1, 2]
+      equal @result, 3
+
+  addition = new Addition(worker, args: [1, 2])
+  addition.invoke()
+
+test 'crash the worker', () ->
+  expect 2
+
+  class Crash extends queue.Template
+    perform: () ->
+      ok true, 'should go through here'
+      throw new Error
+
+  worker =
+    complete: (err) ->
+      ok !!err
+
+  crash = new Crash(worker, args: [])
+  crash.invoke()

--- a/test/tests.coffee
+++ b/test/tests.coffee
@@ -1,0 +1,20 @@
+testRunner = require 'qunit'
+fs = require 'fs'
+path = require 'path'
+
+tests = fs.readdirSync(__dirname).
+            map((file) -> path.join __dirname, file).
+            filter((file) -> /\.js/.test(file) and file isnt __filename)
+
+options = testRunner.options
+options.coverage = true
+
+log = options.log
+log.assertions = false
+log.tests = false
+log.summary = false
+
+testRunner.run(
+  { code: path.join(__dirname, '../lib/queue.js'), tests }
+  (err) -> console.error(err) if err
+)

--- a/test/utils/db.coffee
+++ b/test/utils/db.coffee
@@ -1,0 +1,17 @@
+mongodb = require 'mongodb'
+
+exports.conn = null
+
+exports.connect = (connStr, callback) ->
+  mongodb.MongoClient.connect connStr, (err, db) ->
+    callback(err) if err
+    db.dropDatabase (err) ->
+      callback(err) if err
+      exports.conn = db
+      callback()
+
+exports.teardown = (callback) ->
+  exports.conn.dropDatabase () ->
+    exports.conn.close true, () ->
+      exports.conn = null
+      callback()

--- a/test/worker.coffee
+++ b/test/worker.coffee
@@ -1,0 +1,84 @@
+_ = require 'lodash'
+queue = require '..'
+db = require './utils/db'
+
+QUnit.module 'Worker',
+  teardown: () ->
+    stop()
+    db.teardown () ->
+      start()
+
+test 'test worker with one task', () ->
+  expect 12
+
+  stop()
+
+  db.connect 'mongodb://localhost:27017/test-worker', (err) ->
+    ok !err, 'connection to mongodb failed'
+
+    class Addition extends queue.Template
+      perform: (a, b) ->
+        ok true
+        db.conn.collection('queue').findOne {}, (err, doc) =>
+          ok !err, 'error finding the task'
+          equal doc.queue, 'Addition'
+          ok _.isDate(doc.expires)
+          deepEqual doc.args, [1, 1]
+          equal doc.attempts, 0
+          ok _.isDate(doc.timeout)
+          ok _.isString(doc.owner)
+          @complete()
+
+    conn = new queue.Connection(db: db.conn)
+    conn.on 'error', (err) ->
+      ok false, err
+
+    conn.enqueue Addition.name, 1, 1, () ->
+      ok true, 'should be called when enqueued'
+
+    worker = new queue.Worker conn, [ Addition ]
+    worker.on 'error', () ->
+      ok false, 'there was an error on the worker'
+
+    worker.once 'drained', () ->
+      worker.once 'stopped', () ->
+        db.conn.collection('queue').count (err, count) ->
+          ok !err, 'error counting'
+          equal count, 0
+          start()
+      worker.stop()
+
+    worker.poll()
+
+test 'test worker with a task erroring', () ->
+  expect 9
+
+  stop()
+
+  db.connect 'mongodb://localhost:27017/test-worker', (err) ->
+    ok !err, 'connection to mongodb failed'
+
+    class Addition extends queue.Template
+      perform: (a, b) ->
+        @complete new Error('task error')
+
+    conn = new queue.Connection(db: db.conn)
+    conn.on 'error', (err) ->
+      ok false, err
+
+    conn.enqueue Addition.name, 1, 2, () ->
+      ok true, 'should be called when enqueued'
+
+    worker = new queue.Worker conn, [ Addition ]
+    worker.on 'error', (err) ->
+      equal err.message, 'task error'
+
+    worker.once 'drained', () ->
+      worker.once 'stopped', () ->
+        db.conn.collection('queue').findOne {}, (err, doc) ->
+          ok !err, 'error finding task'
+          equal doc.attempts, 5
+          start()
+      worker.stop()
+
+    worker.poll()


### PR DESCRIPTION
So here's the massive PR as discussed in #9 with tests and all.
A new API to `stop` the worker, much needed in the context of tests, maybe not for the user.
A new event `connected` on the connection to know when the initial setup is done.
A few bug fixes to return on error, otherwise it would be unpredictable.
Hopefully no breaking change.
